### PR TITLE
Added Mosquitto as MQTT broker with TLS only

### DIFF
--- a/config/mosquitto.conf
+++ b/config/mosquitto.conf
@@ -1,0 +1,15 @@
+# Allow persistance, so publishers can use 'retain' flag
+persistence true
+persistence_location /mosquitto/data/
+message_size_limit 1024
+per_listener_settings false
+connection_messages true
+log_dest stdout
+log_type error warning information
+#log_type all
+
+# If "false" then allow only users from 'password_file'
+allow_anonymous false
+
+# Passwords should be defined in config/secrets/mosquitto_users on the host machine
+password_file /mosquitto/config/users

--- a/config/secrets/mosquitto_users
+++ b/config/secrets/mosquitto_users
@@ -1,0 +1,2 @@
+# admin:admin you have to change that later on with mosquitto_passwd after logging into mosquitto container
+admin:$6$6sEXLtWkVz5Ctg6U$76EUB6Ogi+AH6tV0enxrbN14dFBrFIVF/3RG17SQoKTTCWxDIKyKrY9QZ8M+eXs9KPIzqqf8pDWmzPDU9WjUWg==

--- a/config/traefik.yml
+++ b/config/traefik.yml
@@ -1,14 +1,16 @@
 entryPoints:
   https:
-    address: ":443"
+    address: ":443/tcp"
   http:
-    address: ":80"
+    address: ":80/tcp"
   metrics:
-    address: ":8082"
+    address: ":8082/tcp"
   dns53tcp:
     address: ":53/tcp"
   dns53udp:
     address: ":53/udp"
+  mqtt:
+    address: ":8883/tcp"
 
 global:
   checkNewVersion: true

--- a/mosquitto.yml
+++ b/mosquitto.yml
@@ -1,0 +1,29 @@
+version: '3.8'
+
+services:
+
+  mqtt:
+    image: eclipse-mosquitto:1.6.12-openssl
+    container_name: mosquitto
+    restart: always
+    security_opt:
+      - no-new-privileges:true
+    ports:
+      - 1883/tcp
+    depends_on:
+      - traefik
+    labels:
+      - "traefik.enable=true"
+      - "traefik.tcp.services.mqtt.loadbalancer.server.port=1883"
+      - "traefik.tcp.routers.tcpr_mqtt.entrypoints=mqtt"
+      - "traefik.tcp.routers.tcpr_mqtt.rule=HostSNI(`*`)"
+      - "traefik.tcp.routers.tcpr_mqtt.service=mqtt"
+      - "traefik.tcp.routers.tcpr_mqtt.tls=true"
+    volumes:
+      - ./config/mosquitto.conf:/mosquitto/config/mosquitto.conf:ro,rslave
+      - ./config/secrets/mosquitto_users:/mosquitto/config/users:ro,rslave
+    networks:
+      - traefik-public
+
+volumes:
+  mosquittoData:

--- a/traefik.yml
+++ b/traefik.yml
@@ -9,8 +9,9 @@ services:
     security_opt:
       - no-new-privileges:true
     ports:
-      - 80:80
-      - 443:443
+      - 80:80/tcp
+      - 443:443/tcp
+      - 8883:8883/tcp
       - 53:53
       - 53:53/udp
     deploy:


### PR DESCRIPTION
Connect to port `:8883/tcp` with TLS enabled and make sure CA.crt is trusted on your device